### PR TITLE
Signing initial files, after verifying they match original sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,14 @@ Please use the following means for contributions, questions, and support.
 [ML]: http://www.freelists.org/list/geekcrypt
 [WC]: https://webchat.oftc.net/?channels=%23CipherShed
 [IRC]: ircs://irc.oftc.net:6697/CipherShed
+
+Initial signature:
+
+Bill Cox verified and asserts that all files in the CipherShed commit:
+    bb17dcbf0af66362fb119217f5478a016fe60856
+are identical to the original TrueCrypt 7.1a source files extracted from 
+    TrueCrypt 7.1a Source.tar.gz
+with sha256sum:
+    e6214e911d0bbededba274a2f8f8d7b3f6f6951e20f1c3a598fc7a23af81c8dc
+Some files have been added, but there are no other changes.  This commit should have a
+verified signature by Bill Cox, GPG key id 0xD684193E


### PR DESCRIPTION
Signed-off-by: Bill Cox bill@triadsemi.com
I manually verified that all the source files in the previous commit bb17dcbf0af66362fb119217f5478a016fe60856 were identical to the original TrueCrypt 7.1a source.  Some files have been added, but the original files remain intact.   This signature is to put a stake in the ground where we can claim we are confident the source has not been tampered with, at least relative to the original source tarball with sha256 sum e6214e911d0bbededba274a2f8f8d7b3f6f6951e20f1c3a598fc7a23af81c8dc.
