### PR TITLE
Optionally force compilation with MacFUSE.

### DIFF
--- a/src/Driver/Fuse/Driver.make
+++ b/src/Driver/Fuse/Driver.make
@@ -11,6 +11,10 @@ NAME := Driver
 OBJS :=
 OBJS += FuseService.o
 
-CXXFLAGS += $(shell pkg-config fuse --cflags)
+ifdef NOPKGCONFIG
+	CXXFLAGS += -I/usr/local/include/fuse -D__FreeBSD__=10 -D_FILE_OFFSET_BITS=64
+else
+	CXXFLAGS += $(shell pkg-config fuse --cflags)
+endif
 
 include $(BUILD_INC)/Makefile.inc

--- a/src/Main/Main.make
+++ b/src/Main/Main.make
@@ -96,7 +96,11 @@ endif
 
 #------ FUSE configuration ------
 
-FUSE_LIBS = $(shell pkg-config fuse --libs)
+ifdef NOPKGCONFIG
+	FUSE_LIBS = -L/usr/local/lib -lfuse -pthread -liconv
+else
+	FUSE_LIBS = $(shell pkg-config fuse --libs)
+endif
 
 
 #------ Executable ------

--- a/src/Makefile
+++ b/src/Makefile
@@ -11,6 +11,7 @@
 # DEBUGGER:		Enable debugging information for use by debuggers
 # NOASM:		Exclude modules requiring assembler
 # NOGUI:		Disable graphical user interface (build console-only application)
+# NOPKGCONFIG	Do not use pkg-config for FUSE: force MacFUSE usage (OS X-only)
 # NOSTRIP:		Do not strip release binary
 # NOTEST:		Do not test release binary
 # RESOURCEDIR:	Run-time resource directory
@@ -235,6 +236,10 @@ endif
 
 
 #------ Common configuration ------
+
+ifneq "$(PLATFORM)" "MacOSX"
+	undef NOPKGCONFIG
+endif
 
 CFLAGS := $(C_CXX_FLAGS) $(CFLAGS) $(TC_EXTRA_CFLAGS)
 CXXFLAGS := $(C_CXX_FLAGS) $(CXXFLAGS) $(TC_EXTRA_CXXFLAGS)


### PR DESCRIPTION
Use known MacFUSE compiler and linker options instead of pkg-config when
building with NOPKGCONFIG. An official build should compile with MacFUSE
to make sure the application will work regardless of whether an end-user's
system is using MacFUSE or its successor OSXFUSE (with MacFUSE
compatibility).
Not using pkg-config also has the advantage of not having to install
pkg-config (through e.g. MacPorts, Fink, or Homebrew) which makes it
easier to do a build on an offline system.
