### PR TITLE
Review

### DIFF
--- a/src/Core/FatFormatter.cpp
+++ b/src/Core/FatFormatter.cpp
@@ -154,7 +154,7 @@ namespace CipherShed
 		boot[cnt++] = 0xeb;	/* boot jump */
 		boot[cnt++] = 0x3c;
 		boot[cnt++] = 0x90;
-		memcpy (boot + cnt, "CPHSHED", 8); /* system id */
+		memcpy (boot + cnt, "CPHSHED ", 8); /* system id */
 		cnt += 8;
 		*(int16 *)(boot + cnt) = Endian::Little (ft->sector_size);	/* bytes per sector */
 		cnt += 2;


### PR DESCRIPTION
I removed MS-DOS OEM ID and set it into CPHSHED to alleviate the false impression that the partition has been formatted with MS-DOS format.com.
